### PR TITLE
Add missing certificate functions

### DIFF
--- a/pkg/js_chain_libs.js.flow
+++ b/pkg/js_chain_libs.js.flow
@@ -559,6 +559,13 @@ declare export class Certificate {
   static stake_delegation(stake_delegation: StakeDelegation): Certificate;
 
   /**
+   * Create a Certificate for OwnerStakeDelegation
+   * @param {OwnerStakeDelegation} owner_stake
+   * @returns {Certificate}
+   */
+  static owner_stake_delegation(owner_stake: OwnerStakeDelegation): Certificate;
+
+  /**
    * Create a Certificate for PoolRegistration
    * @param {PoolRegistration} pool_registration
    * @returns {Certificate}
@@ -573,6 +580,13 @@ declare export class Certificate {
    * @returns {Certificate}
    */
   static stake_pool_retirement(pool_retirement: PoolRetirement): Certificate;
+
+  /**
+   * Create a Certificate for PoolUpdate
+   * @param {PoolUpdate} pool_update
+   * @returns {Certificate}
+   */
+  static stake_pool_update(pool_update: PoolUpdate): Certificate;
 
   /**
    * @returns {CertificateKindType}
@@ -598,6 +612,11 @@ declare export class Certificate {
    * @returns {PoolRetirement}
    */
   get_pool_retirement(): PoolRetirement;
+
+  /**
+   * @returns {PoolUpdate}
+   */
+  get_pool_update(): PoolUpdate;
 }
 /**
  * Delegation Ratio type express a number of parts
@@ -861,6 +880,37 @@ declare export class Fragments {
    * @param {Fragment} item
    */
   add(item: Fragment): void;
+}
+/**
+ */
+declare export class GenesisPraosLeader {
+  free(): void;
+
+  /**
+   * @param {KesPublicKey} kes_public_key
+   * @param {VrfPublicKey} vrf_public_key
+   * @returns {GenesisPraosLeader}
+   */
+  static new(
+    kes_public_key: KesPublicKey,
+    vrf_public_key: VrfPublicKey
+  ): GenesisPraosLeader;
+}
+/**
+ */
+declare export class GenesisProasLeaderHash {
+  free(): void;
+
+  /**
+   * @param {string} hex_string
+   * @returns {GenesisProasLeaderHash}
+   */
+  static from_hex(hex_string: string): GenesisProasLeaderHash;
+
+  /**
+   * @returns {string}
+   */
+  to_string(): string;
 }
 /**
  */
@@ -1297,6 +1347,17 @@ declare export class OwnerStakeDelegation {
    * @returns {DelegationType}
    */
   delegation_type(): DelegationType;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  as_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {OwnerStakeDelegation}
+   */
+  static from_bytes(bytes: Uint8Array): OwnerStakeDelegation;
 }
 /**
  */
@@ -1424,8 +1485,7 @@ declare export class PoolRegistration {
    * @param {PublicKeys} operators
    * @param {number} management_threshold
    * @param {TimeOffsetSeconds} start_validity
-   * @param {KesPublicKey} kes_public_key
-   * @param {VrfPublicKey} vrf_public_key
+   * @param {GenesisPraosLeader} leader_keys
    * @returns {PoolRegistration}
    */
   constructor(
@@ -1434,8 +1494,7 @@ declare export class PoolRegistration {
     operators: PublicKeys,
     management_threshold: number,
     start_validity: TimeOffsetSeconds,
-    kes_public_key: KesPublicKey,
-    vrf_public_key: VrfPublicKey
+    leader_keys: GenesisPraosLeader
   ): this;
 
   /**
@@ -1454,9 +1513,35 @@ declare export class PoolRegistration {
   owners(): PublicKeys;
 
   /**
+   * @returns {PublicKeys}
+   */
+  operators(): PublicKeys;
+
+  /**
    * @returns {TaxType}
    */
   rewards(): TaxType;
+
+  /**
+   * @returns {Account}
+   */
+  reward_account(): Account | void;
+
+  /**
+   * @returns {GenesisPraosLeader}
+   */
+  keys(): GenesisPraosLeader;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  as_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {PoolRegistration}
+   */
+  static from_bytes(bytes: Uint8Array): PoolRegistration;
 }
 /**
  */
@@ -1473,6 +1558,87 @@ declare export class PoolRegistrationAuthData {
  */
 declare export class PoolRetirement {
   free(): void;
+
+  /**
+   * @param {PoolId} pool_id
+   * @param {TimeOffsetSeconds} retirement_time_offset
+   * @returns {PoolRetirement}
+   */
+  static new(
+    pool_id: PoolId,
+    retirement_time_offset: TimeOffsetSeconds
+  ): PoolRetirement;
+
+  /**
+   * @returns {PoolId}
+   */
+  pool_id(): PoolId;
+
+  /**
+   * @returns {TimeOffsetSeconds}
+   */
+  retirement_time(): TimeOffsetSeconds;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  as_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {PoolRetirement}
+   */
+  static from_bytes(bytes: Uint8Array): PoolRetirement;
+}
+/**
+ */
+declare export class PoolUpdate {
+  free(): void;
+
+  /**
+   * @param {PoolId} pool_id
+   * @param {TimeOffsetSeconds} start_validity
+   * @param {GenesisProasLeaderHash} previous_keys
+   * @param {GenesisPraosLeader} updated_keys
+   * @returns {PoolUpdate}
+   */
+  static new(
+    pool_id: PoolId,
+    start_validity: TimeOffsetSeconds,
+    previous_keys: GenesisProasLeaderHash,
+    updated_keys: GenesisPraosLeader
+  ): PoolUpdate;
+
+  /**
+   * @returns {PoolId}
+   */
+  pool_id(): PoolId;
+
+  /**
+   * @returns {TimeOffsetSeconds}
+   */
+  start_validity(): TimeOffsetSeconds;
+
+  /**
+   * @returns {GenesisProasLeaderHash}
+   */
+  previous_keys(): GenesisProasLeaderHash;
+
+  /**
+   * @returns {GenesisPraosLeader}
+   */
+  updated_keys(): GenesisPraosLeader;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  as_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {PoolUpdate}
+   */
+  static from_bytes(bytes: Uint8Array): PoolUpdate;
 }
 /**
  */
@@ -1681,6 +1847,17 @@ declare export class StakeDelegation {
    * @returns {AccountIdentifier}
    */
   account(): AccountIdentifier;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  as_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {StakeDelegation}
+   */
+  static from_bytes(bytes: Uint8Array): StakeDelegation;
 }
 /**
  */


### PR DESCRIPTION
This PR does a few things

1) Bumps `chain-libs` to include some missing functionality
2) Add the missing `PoolUpdate` certificate type
3) Adds the missing functions for multiple certificate types
4) Adds a `from_bytes` and `as_bytes` function to all certificate types