### PR TITLE
Use per-certificate fee

### DIFF
--- a/pkg/js_chain_libs.js.flow
+++ b/pkg/js_chain_libs.js.flow
@@ -750,13 +750,16 @@ declare export class Fee {
    * @param {Value} constant
    * @param {Value} coefficient
    * @param {Value} certificate
+   * @param {PerCertificateFee} per_certificate_fee
    * @returns {Fee}
    */
   static linear_fee(
     constant: Value,
     coefficient: Value,
-    certificate: Value
+    certificate: Value,
+    per_certificate_fee: PerCertificateFee
   ): Fee;
+
 
   /**
    * @param {Transaction} tx
@@ -1454,6 +1457,31 @@ declare export class PayloadAuthData {
    * @returns {PayloadAuthData}
    */
   static for_pool_update(auth_data: PoolUpdateAuthData): PayloadAuthData;
+}
+/**
+ */
+declare export class PerCertificateFee {
+  free(): void;
+
+  /**
+   * @returns {PerCertificateFee}
+   */
+  static new(): PerCertificateFee;
+
+  /**
+   * @param {Value} val
+   */
+  set_pool_registration(val: Value): void;
+
+  /**
+   * @param {Value} val
+   */
+  set_stake_delegation(val: Value): void;
+
+  /**
+   * @param {Value} val
+   */
+  set_owner_stake_delegation(val: Value): void;
 }
 /**
  */


### PR DESCRIPTION
Shelley ITN uses special per-certificate fees for both stake delegation and for pool registration. This PR adds the ability to specify these